### PR TITLE
Fix bug missing appid

### DIFF
--- a/steam2sqlite/handler.py
+++ b/steam2sqlite/handler.py
@@ -30,7 +30,6 @@ def get_or_create(session, model, **kwargs):
 
 
 def update_or_create(session, model, filterargs, **kwargs):
-
     try:
         instance = session.exec(select(model).filter_by(**filterargs)).one_or_none()
     except sqlalchemy.exc.MultipleResultsFound:
@@ -51,7 +50,6 @@ def update_or_create(session, model, filterargs, **kwargs):
 def attach_achievements_to_app(
     session: Session, app_achievements_dict: list[dict], app: SteamApp
 ):
-
     for achievement_dict in app_achievements_dict:
         achievement_args = achievement_dict | {"steam_app": app}  # joining dicts
         update_or_create(
@@ -78,7 +76,6 @@ def clear_and_store_achievements(
 
 
 def get_apps_achievements(apps: list[SteamApp]) -> list[tuple[SteamApp, list[dict]]]:
-
     urls = [ACHIEVEMENT_URL.format(app.appid) for app in apps]
     responses = asyncio.run(navigator.make_requests(urls))
 
@@ -122,7 +119,6 @@ def store_apps_achievements(
 
 
 def load_app_into_db(session: Session, data: dict) -> SteamApp:
-
     genres_data = data.get("genres") or []
     if genres_data:
         # deduplicate
@@ -196,7 +192,6 @@ def load_app_into_db(session: Session, data: dict) -> SteamApp:
 
 
 def import_single_app(session: Session, item: dict) -> SteamApp:
-
     appid = list(item.keys())[0]
     if item[appid]["success"] is False:
         raise DataParsingError(int(appid), reason="Response from api: success=False")
@@ -241,7 +236,6 @@ def record_appid_error(
 def get_apps_data(
     session: Session, steam_appids_names: dict[int, str], appids: list[int]
 ) -> list[dict]:
-
     urls = [APPID_URL.format(appid) for appid in appids if appid is not None]
     responses = asyncio.run(navigator.make_requests(urls))
 

--- a/steam2sqlite/navigator.py
+++ b/steam2sqlite/navigator.py
@@ -22,7 +22,7 @@ async def get(
         resp = await client.get(url, headers=headers)
         resp.raise_for_status()
     except (httpx.HTTPError, ssl.SSLError) as e:
-        if wait_time > 2 ** 6:
+        if wait_time > 2**6:
             logger.exception(f"Response never succeeded on url {url}")
             raise NavigatorError(url=url) from e
         logger.error(f"Error in response, trying again in: {wait_time}s")
@@ -39,7 +39,6 @@ async def make_requests(urls: list[str]) -> list[httpx.Response]:
     async with httpx.AsyncClient(
         headers={"accept": "application/json"}, timeout=10, limits=limits
     ) as client:
-
         tasks = [get(client, url) for url in urls]
         responses = await asyncio.gather(*tasks, return_exceptions=True)
 

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -2,6 +2,7 @@ import json
 
 import pytest
 from sqlmodel import Session, create_engine
+
 from steam2sqlite import handler, models
 
 steam_appids_names = {620: "Portal 2", 659: "Portal 2 - Pre-order"}
@@ -79,7 +80,6 @@ def test_app_with_duplicated_appid(session):
 
 
 def test_ingest_item_twice(session: Session):
-
     appid = "620"
     app_data = get_apps_data([appid])[0]
 
@@ -207,7 +207,6 @@ def test_duplicate_acheievemnts_on_app(
 
 
 def test_update_column_updated(session: Session, portal_app: models.SteamApp):
-
     # assert our initial data
     assert portal_app.is_free is False
 
@@ -236,7 +235,6 @@ def test_price_present(session: Session, portal_app: models.SteamApp):
 
 
 def test_price_update(session: Session, portal_app: models.SteamApp):
-
     appid = str(portal_app.appid)
     app_data = get_apps_data([appid])[0]
 

--- a/tests/test_steam2sqlite.py
+++ b/tests/test_steam2sqlite.py
@@ -2,4 +2,4 @@ from steam2sqlite import __version__
 
 
 def test_version():
-    assert __version__ == '0.1.0'
+    assert __version__ == "0.1.0"


### PR DESCRIPTION
we had been attempting to get info on apps that no longer exist in the steam database

which we were catching, but then raising an exception as we tried to write out the error in the log, as we didn't even have a correct record of the apps name